### PR TITLE
Adapt to new modm-devices pinout format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ tgcurses:
 
 
 modm-devices:
-	@git clone -b develop_with_gpio_xml https://github.com/tgree/modm-devices
+	@git clone https://github.com/modm-io/modm-devices
 
 
 .xml: modm-devices
@@ -19,7 +19,7 @@ modm-devices:
 
 
 modm_devices: modm-devices
-	@ln -s modm-devices/tools/device/modm_devices
+	@ln -s modm-devices/modm_devices
 
 
 clean:

--- a/stm_layout.py
+++ b/stm_layout.py
@@ -360,9 +360,10 @@ if __name__ == '__main__':
     rv = parser.parse_args()
 
     parts = chip_db.find(rv.chip)
-    if len(parts) > 1:
+    part = next( (p for p in parts if rv.chip == p.partname), None)
+    if part is None:
         for p in parts:
-            print('%s - %s%s' % (p, chip_db.package(p), chip_db.pin_count(p)))
+            print('%s - %s' % (p, chip_db.package(p)))
     else:
         chip = chip_stm.make_chip(parts[0])
         tgcurses.wrapper(main, chip)


### PR DESCRIPTION
The pinout information is now stored in a separate list instead of being
part of the GPIO table. To ensure that this format is useful for you, I've refactored the data intake to use the new format.

I've merged the modm-devices pull request https://github.com/modm-io/modm-devices/pull/46 and published `modm_devices@v0.2.0`.

cc @tgree.