### PR TITLE
Fix for exact identifier match

### DIFF
--- a/stm_layout/chip_db.py
+++ b/stm_layout/chip_db.py
@@ -11,11 +11,12 @@ from . import chip_package
 DEVICES = None
 
 
-def _populate_devices():
+def _populate_devices(prefix=None):
     global DEVICES
     DEVICES = {}
     basedir = modm_devices.pkg.get_filename('modm_devices', 'resources/devices')
-    for filename in glob.glob('%s/**/*.xml' % basedir):
+    if prefix is None: prefix = "";
+    for filename in glob.glob('{}/**/{}*.xml'.format(basedir, prefix)):
         parser  = modm_devices.parser.DeviceParser()
         devfile = parser.parse(filename)
         for device in devfile.get_devices():
@@ -24,7 +25,7 @@ def _populate_devices():
 
 def find(name):
     if DEVICES is None:
-        _populate_devices()
+        _populate_devices(name[:7])
 
     devs = []
     for partname, dev in DEVICES.items():

--- a/stm_layout/stm_layout.py
+++ b/stm_layout/stm_layout.py
@@ -362,11 +362,17 @@ def _main():
     rv = parser.parse_args()
 
     parts = chip_db.find(rv.chip)
-    if len(parts) > 1:
+    if not parts:
+        print('No devices found for "%s"' % rv.chip)
+        exit(1)
+    part = next( (p for p in parts if rv.chip == p.partname), None)
+    if part is None:
+        print('Multiple devices found for "%s"' % rv.chip)
         for p in parts:
             print('%s - %s' % (p, chip_db.package(p)))
+        exit(1)
     else:
-        chip = chip_stm.make_chip(parts[0])
+        chip = chip_stm.make_chip(part)
         tgcurses.wrapper(main, chip)
 
 


### PR DESCRIPTION
Some devices have an extra suffix, for example, there's the `stm32g071gbu6` and `stm32g071gbu6n`, which have slightly different pinouts (because ST is weird).
```
 $ stm_layout -c stm32g071gbu6
stm32g071gbu6n - UFQFPN28
stm32g071gbu6 - UFQFPN28
```

This patch searches for an exact match, instead of just a prefix. 
I also added better error message and an exit code.

This also filters the device files by family name, so that you only have to parse a few device files, which makes finding the device basically instantaneous.

cc @tgree 